### PR TITLE
chore:  better organize/name workflows for pull requests and deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,81 +3,15 @@ on:
   push:
     branches:
       - main
-  pull_request: {}
 
 permissions:
   actions: write
   contents: read
 
 jobs:
-  lint:
-    name: ⬣ ESLint
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
-
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
-        with:
-          useLockFile: false
-
-      - name: 🔬 Lint
-        run: npm run lint
-
-  typecheck:
-    name: ʦ TypeScript
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
-
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
-        with:
-          useLockFile: false
-
-      - name: 🔎 Type check
-        run: npm run typecheck --if-present
-  #
-  # vitest:
-  #   name: ⚡ Vitest
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: 🛑 Cancel Previous Runs
-  #       uses: styfle/cancel-workflow-action@0.11.0
-
-  #     - name: ⬇️ Checkout repo
-  #       uses: actions/checkout@v3
-
-  #     - name: ⎔ Setup node
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: 16
-
-  #     - name: 📥 Download deps
-  #       uses: bahmutov/npm-install@v1
-  #       with:
-  #         useLockFile: false
-
-  #     - name: ⚡ Run vitest
-  #       run: npm run test -- --coverage
+  development:
+    name: Lint, Typecheck & Test
+    uses: remix-austin/remixaustin-com/.github/workflows/development.yml@main
 
   # cypress:
   #   name: ⚫️ Cypress
@@ -178,8 +112,7 @@ jobs:
   deploy:
     name: 🚀 Deploy
     runs-on: ubuntu-latest
-    # needs: [lint, typecheck, vitest, cypress, build] # TODO: excluding testing for now, needs fixin'
-    needs: [lint, build]
+    needs: [development, build]
     # only build/deploy main branch on pushes
     if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
 

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,0 +1,76 @@
+name: 🧪 Development
+workflow_call:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  lint:
+    name: ⬣ ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: 📥 Download deps
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
+
+      - name: 🔬 Lint
+        run: npm run lint
+
+  typecheck:
+    name: ʦ TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: 📥 Download deps
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
+
+      - name: 🔎 Type check
+        run: npm run typecheck --if-present
+
+  # vitest:
+  #   name: ⚡ Vitest
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: 🛑 Cancel Previous Runs
+  #       uses: styfle/cancel-workflow-action@0.11.0
+
+  #     - name: ⬇️ Checkout repo
+  #       uses: actions/checkout@v3
+
+  #     - name: ⎔ Setup node
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 16
+
+  #     - name: 📥 Download deps
+  #       uses: bahmutov/npm-install@v1
+  #       with:
+  #         useLockFile: false
+
+  #     - name: ⚡ Run vitest
+  #       run: npm run test -- --coverage

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,14 @@
+name: "🙋 Pull Request"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  development:
+    name: Lint, Typecheck & Test
+    uses: remix-austin/remixaustin-com/.github/workflows/development.yml@main

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # RemixAustin.com
 
-![example workflow](https://github.com/remix-austin/remixaustin-com/actions/workflows/deploy.yml/badge.svg)
-
 <img src="public/img/remix-logo-rainbow.jpg" width="600" alt="Remix Austin logo" />
 
 The public repository for the [RemixAustin.com](https://remixaustin.com) website.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RemixAustin.com
 
+![example workflow](https://github.com/remix-austin/remixaustin-com/actions/workflows/deploy.yml/badge.svg)
+
 <img src="public/img/remix-logo-rainbow.jpg" width="600" alt="Remix Austin logo" />
 
 The public repository for the [RemixAustin.com](https://remixaustin.com) website.


### PR DESCRIPTION
Separates linting, typechecking & testing into `Development` workflow, then both `Pull Request` and `Deploy` workflows reference the reusable one.

Fixes #17