### PR TITLE
chore: fix github actions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,4 +1,14 @@
 name: 🧪 Development
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
 workflow_call:
 
 permissions:


### PR DESCRIPTION
Fix `Invalid workflow file` error, caused by missing `on` trigger