### PR TITLE
chore:  fix workflow_call trigger

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -9,7 +9,7 @@ on:
       - edited
       - synchronize
       - reopened
-workflow_call:
+  workflow_call:
 
 permissions:
   actions: write


### PR DESCRIPTION
`workflow_call` was not indented correctly