### PR TITLE
chore:  Make the build step in Deploy workflow dependent on the development step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   development:
-    name: Lint, Typecheck & Test
+    name: Development
     uses: remix-austin/remixaustin-com/.github/workflows/development.yml@main
 
   # cypress:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
     # only build/deploy main branch on pushes
     if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    needs: [development]
     steps:
       - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   development:
-    name: Lint, Typecheck & Test
+    name: Development
     uses: remix-austin/remixaustin-com/.github/workflows/development.yml@main


### PR DESCRIPTION
chore:  Make the build step in Deploy workflow dependent on the development step