### PR TITLE
Update Cypress from 10.8 to 11.2

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -93,16 +93,16 @@ jobs:
         with:
           node-version: 16
 
-      - name: Cypress info
-        run: npx cypress info
-
-      - name: Node info
-        run: node -v
-
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
         with:
           useLockFile: false
+
+      - name: Node info
+        run: node -v
+
+      - name: Cypress info
+        run: npx cypress info
 
       - name: ⚙️ Build
         run: npm run build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,4 +10,4 @@ on:
 jobs:
   development:
     name: 👷 Development
-    uses: remix-austin/remixaustin-com/.github/workflows/development.yml@gkn/update-cypress-to-11.2.0
+    uses: remix-austin/remixaustin-com/.github/workflows/development.yml@main

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,4 +10,4 @@ on:
 jobs:
   development:
     name: 👷 Development
-    uses: remix-austin/remixaustin-com/.github/workflows/development.yml@main
+    uses: remix-austin/remixaustin-com/.github/workflows/development.yml@gkn/update-cypress-to-11.2.0

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ You can, however, [create an issue](https://github.com/remix-austin/remixaustin-
 
 ### Cypress
 
+[![Cypress.io](https://img.shields.io/badge/tested%20with-Cypress-04C38E.svg)](https://www.cypress.io/)
+
 We use Cypress for our End-to-End tests in this project. You'll find those in the `cypress` directory. As you make changes, add to an existing file or create a new file in the `cypress/e2e` directory to test your changes.
 
 We use [`@testing-library/cypress`](https://testing-library.com/cypress) for selecting elements on the page semantically.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RemixAustin.com
 
-[![remixaustin.com](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/detailed/6s6892/main&style=flat&logo=cypress)](https://cloud.cypress.io/projects/6s6892/runs)
+[![Deploy](https://github.com/remix-austin/remixaustin-com/actions/workflows/deploy/badge.svg?branch=main)](.github/workflows/deploy.yml) [![remixaustin.com](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/detailed/6s6892/main&style=flat&logo=cypress)](https://cloud.cypress.io/projects/6s6892/runs)
 
 <img src="public/img/remix-logo-rainbow.jpg" width="600" alt="Remix Austin logo" />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "c8": "^7.12.0",
         "cookie": "^0.5.0",
         "cross-env": "^7.0.3",
-        "cypress": "^10.8.0",
+        "cypress": "11.2.0",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-cypress": "^2.12.1",
@@ -5506,9 +5506,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.11.0.tgz",
-      "integrity": "sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
+      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -22005,9 +22005,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.11.0.tgz",
-      "integrity": "sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
+      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "c8": "^7.12.0",
     "cookie": "^0.5.0",
     "cross-env": "^7.0.3",
-    "cypress": "^10.8.0",
+    "cypress": "11.2.0",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-cypress": "^2.12.1",


### PR DESCRIPTION
chore: Update Cypress from 10.8 to 11.2.  Re-order Cypress workflow steps to run "npm install" before showing "cypress info".

Also, trying to debug the `Could not find Cypress test run results` error when running Cypress tests from `main`.