### PR TITLE
Add a redirectToNonWww function to remove "www" from urls

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,7 +16,7 @@ import Footer from "./components/Footer/Footer";
 import Navbar from "./components/Navbar/Navbar";
 
 import tailwindStylesheetUrl from "./styles/tailwind.css";
-import { redirectToNonWww } from "./utils";
+import { getRedirectUrlIfWww } from "./utils";
 
 export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: tailwindStylesheetUrl }];
@@ -30,7 +30,7 @@ export const meta: MetaFunction = () => ({
 
 export const loader: LoaderFunction = async ({ request }) => {
   // Redirect if "www." is in the url.
-  const redirectUrl = redirectToNonWww(request.url);
+  const redirectUrl = getRedirectUrlIfWww(request.url);
   if (redirectUrl) {
     return redirect(redirectUrl, 308);
   }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,9 @@
-import type { LinksFunction, MetaFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import type {
+  LinksFunction,
+  LoaderFunction,
+  MetaFunction,
+} from "@remix-run/node";
 import {
   Links,
   LiveReload,
@@ -11,6 +16,7 @@ import Footer from "./components/Footer/Footer";
 import Navbar from "./components/Navbar/Navbar";
 
 import tailwindStylesheetUrl from "./styles/tailwind.css";
+import { redirectToNonWww } from "./utils";
 
 export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: tailwindStylesheetUrl }];
@@ -21,6 +27,16 @@ export const meta: MetaFunction = () => ({
   title: "Remix Austin 💿",
   viewport: "width=device-width,initial-scale=1",
 });
+
+export const loader: LoaderFunction = async ({ request }) => {
+  // Redirect if "www." is in the url.
+  const redirectUrl = redirectToNonWww(request.url);
+  if (redirectUrl) {
+    return redirect(redirectUrl, 308);
+  }
+
+  return null;
+};
 
 export default function App() {
   return (

--- a/app/utils.test.ts
+++ b/app/utils.test.ts
@@ -1,8 +1,8 @@
-import { validateEmail, safeRedirect } from "./utils";
+import { validateEmail, safeRedirect, redirectToNonWww } from "./utils";
 
 describe("utils", () => {
   describe("email validation", () => {
-    test("validateEmail returns false for non-emails", () => {
+    it("validateEmail returns false for non-emails", () => {
       expect(validateEmail(undefined)).toBe(false);
       expect(validateEmail(null)).toBe(false);
       expect(validateEmail("")).toBe(false);
@@ -10,34 +10,34 @@ describe("utils", () => {
       expect(validateEmail("n@")).toBe(false);
     });
 
-    test("validateEmail returns true for emails", () => {
+    it("validateEmail returns true for emails", () => {
       expect(validateEmail("kody@example.com")).toBe(true);
     });
   });
 
   describe("safeRedirect", () => {
-    test("returns default value if 'to' is null", () => {
+    it("returns default value if 'to' is null", () => {
       const defaultValue = "https://remixaustin.com";
       const result = safeRedirect(null, defaultValue);
 
       expect(result).toBe(defaultValue);
     });
 
-    test("returns default value if 'to' is undefined", () => {
+    it("returns default value if 'to' is undefined", () => {
       const defaultValue = "https://remixaustin.com";
       const result = safeRedirect(undefined, defaultValue);
 
       expect(result).toBe(defaultValue);
     });
 
-    test("returns default value if 'to' is an empty string", () => {
+    it("returns default value if 'to' is an empty string", () => {
       const defaultValue = "https://remixaustin.com";
       const result = safeRedirect("", defaultValue);
 
       expect(result).toBe(defaultValue);
     });
 
-    test("returns default value if 'to' does not begin with '/'", () => {
+    it("returns default value if 'to' does not begin with '/'", () => {
       const defaultValue = "https://remixaustin.com";
       const result = safeRedirect(
         "https://malicious-user-domain.xyz",
@@ -47,14 +47,14 @@ describe("utils", () => {
       expect(result).toBe(defaultValue);
     });
 
-    test("returns default value if 'to' begins with '//'", () => {
+    it("returns default value if 'to' begins with '//'", () => {
       const defaultValue = "https://remixaustin.com";
       const result = safeRedirect("//malicious-user-domain.xyz", defaultValue);
 
       expect(result).toBe(defaultValue);
     });
 
-    test("returns correct value if 'to' begins with '/'", () => {
+    it("returns correct value if 'to' begins with '/'", () => {
       const defaultValue = "https://remixaustin.com";
       const result = safeRedirect("/login", defaultValue);
 
@@ -62,9 +62,39 @@ describe("utils", () => {
     });
   });
 
+  describe("redirectToNonWww", () => {
+    it("returns a non-www redirect url if passed a url with www", () => {
+      const requestUrl = "https://www.remixaustin.com/";
+      const result = redirectToNonWww(requestUrl);
+
+      expect(result).toBe("https://remixaustin.com/");
+    });
+
+    it("returns a non-www redirect url if passed a url with www and no trailing slash", () => {
+      const requestUrl = "https://www.remixaustin.com";
+      const result = redirectToNonWww(requestUrl);
+
+      expect(result).toBe("https://remixaustin.com/");
+    });
+
+    it("returns a non-www redirect url and retains the path & querystring", () => {
+      const requestUrl = "https://www.remixaustin.com/blah/?a=apple&b=banana";
+      const result = redirectToNonWww(requestUrl);
+
+      expect(result).toBe("https://remixaustin.com/blah/?a=apple&b=banana");
+    });
+
+    it("returns null (and therefore no redirect) if the url does not contain www", () => {
+      const requestUrl = "https://remixaustin.com/blah/?a=apple&b=banana";
+      const result = redirectToNonWww(requestUrl);
+
+      expect(result).toBe(null);
+    });
+  });
+
   // TODO
   // describe("useMatchesData", () => {
-  //   test("safeRedirect", () => {
+  //   it("safeRedirect", () => {
   //     expect(validateEmail("kody@example.com")).toBe(true);
   //   });
   // });

--- a/app/utils.test.ts
+++ b/app/utils.test.ts
@@ -1,4 +1,4 @@
-import { validateEmail, safeRedirect, redirectToNonWww } from "./utils";
+import { validateEmail, safeRedirect, getRedirectUrlIfWww } from "./utils";
 
 describe("utils", () => {
   describe("email validation", () => {
@@ -62,31 +62,31 @@ describe("utils", () => {
     });
   });
 
-  describe("redirectToNonWww", () => {
+  describe("getRedirectUrlIfWww", () => {
     it("returns a non-www redirect url if passed a url with www", () => {
       const requestUrl = "https://www.remixaustin.com/";
-      const result = redirectToNonWww(requestUrl);
+      const result = getRedirectUrlIfWww(requestUrl);
 
       expect(result).toBe("https://remixaustin.com/");
     });
 
     it("returns a non-www redirect url if passed a url with www and no trailing slash", () => {
       const requestUrl = "https://www.remixaustin.com";
-      const result = redirectToNonWww(requestUrl);
+      const result = getRedirectUrlIfWww(requestUrl);
 
       expect(result).toBe("https://remixaustin.com/");
     });
 
     it("returns a non-www redirect url and retains the path & querystring", () => {
       const requestUrl = "https://www.remixaustin.com/blah/?a=apple&b=banana";
-      const result = redirectToNonWww(requestUrl);
+      const result = getRedirectUrlIfWww(requestUrl);
 
       expect(result).toBe("https://remixaustin.com/blah/?a=apple&b=banana");
     });
 
     it("returns null (and therefore no redirect) if the url does not contain www", () => {
       const requestUrl = "https://remixaustin.com/blah/?a=apple&b=banana";
-      const result = redirectToNonWww(requestUrl);
+      const result = getRedirectUrlIfWww(requestUrl);
 
       expect(result).toBe(null);
     });

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -33,7 +33,7 @@ export function safeRedirect(
  *
  * Otherwise, return null.
  */
-export const redirectToNonWww = (requestUrl: string): string | null => {
+export const getRedirectUrlIfWww = (requestUrl: string): string | null => {
   const url = new URL(requestUrl);
   const hostname = url.hostname;
 

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -26,6 +26,26 @@ export function safeRedirect(
 }
 
 /**
+ * If the request's url contains "www.", return the non-www version of the url,
+ * and retain all protocol, path & query info.
+ *
+ * A trailing slash will be added to a hostname if missing the path.
+ *
+ * Otherwise, return null.
+ */
+export const redirectToNonWww = (requestUrl: string): string | null => {
+  const url = new URL(requestUrl);
+  const hostname = url.hostname;
+
+  if (/^www\./i.test(hostname)) {
+    const newHost = url.host.replace(/^www\./i, "");
+    return `${url.protocol}//${newHost}${url.pathname}${url.search}`;
+  }
+
+  return null;
+};
+
+/**
  * This base hook is used in other hooks to quickly search for specific data
  * across all loader data using useMatches.
  * @param {string} id The route id


### PR DESCRIPTION
We want to remove the `www` subdomain in order to retain canonical non-www URLs for our pages.

* Added a `redirectToNonWww()` function
* Redirect with an `HTTP 308` if the request url contains `www`

_(Related to https://github.com/remix-austin/remixaustin-com/pull/31)_