### PR TITLE
feat: add the next event's info to the home page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*  text=auto eol=lf

--- a/app/components/MeetupLink.tsx
+++ b/app/components/MeetupLink.tsx
@@ -1,0 +1,19 @@
+import MeetupIcon from "~/components/icons/MeetupIcon";
+import type { PropsWithRequiredChildren } from "~/utils";
+
+export default function MeetupLink({
+  link,
+  children,
+}: PropsWithRequiredChildren<{ link: string }>) {
+  return (
+    <a
+      href={link}
+      className="btn-primary btn mb-8"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <span className="mr-2">{children}</span>
+      <MeetupIcon />
+    </a>
+  );
+}

--- a/app/components/NextEventInfo/NextEventInfo.test.tsx
+++ b/app/components/NextEventInfo/NextEventInfo.test.tsx
@@ -1,0 +1,66 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import type { SerializedMeetupEvent } from "./NextEventInfo";
+import NextEventInfo from "./NextEventInfo";
+
+const DEFAULT_ONLINE_EVENT: SerializedMeetupEvent = {
+  title: "Title",
+  shortUrl: "https://short.url",
+  venue: {
+    name: "Online",
+    address: "",
+    city: "",
+    state: "",
+  },
+  dateTime: "2022-01-01T01:00:00Z",
+  going: 100,
+};
+
+describe("NextEventInfo", () => {
+  it("renders given venue", () => {
+    const eventWithVenue = {
+      ...DEFAULT_ONLINE_EVENT,
+      venue: {
+        name: "Venue name",
+        address: "Venue address",
+        city: "Venue city",
+        state: "Venue state",
+      },
+    };
+    render(<NextEventInfo event={eventWithVenue} />);
+    expect(screen.getByText("Venue name")).toBeInTheDocument();
+    expect(
+      screen.getByText("Venue address, Venue city, Venue state")
+    ).toBeInTheDocument();
+  });
+
+  it("renders default venue for online events", () => {
+    render(<NextEventInfo event={DEFAULT_ONLINE_EVENT} />);
+    expect(
+      screen.getByText("H-E-B Digital & Favor Eastside Tech Hub (and online)")
+    ).toBeInTheDocument();
+    expect(screen.getByText("2416 E 6th St, Austin, TX")).toBeInTheDocument();
+  });
+
+  it("renders date in the correct time zone", () => {
+    render(<NextEventInfo event={DEFAULT_ONLINE_EVENT} />);
+    expect(screen.getByText("Fri, Dec 31, 7:00 PM CST")).toBeInTheDocument();
+  });
+
+  it("renders button label when many are attending", () => {
+    const eventWithManyAttending = { ...DEFAULT_ONLINE_EVENT, going: 10 };
+    render(<NextEventInfo event={eventWithManyAttending} />);
+    expect(
+      screen.getByRole("link", { name: "Join 10 others at our next meetup!" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders button label when no one is attending", () => {
+    const eventWithNoOneAttending = { ...DEFAULT_ONLINE_EVENT, going: 0 };
+    render(<NextEventInfo event={eventWithNoOneAttending} />);
+    expect(
+      screen.getByRole("link", { name: "Join us at our next meetup!" })
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/NextEventInfo/NextEventInfo.tsx
+++ b/app/components/NextEventInfo/NextEventInfo.tsx
@@ -1,0 +1,57 @@
+import type { MeetupEvent } from "~/models/meetup.parsing";
+import { isEmptyString } from "~/utils";
+import MeetupLink from "~/components/MeetupLink";
+import type { SerializeFrom } from "@remix-run/server-runtime";
+
+const DEFAULT_VENUE: MeetupEvent["venue"] = {
+  name: "H-E-B Digital & Favor Eastside Tech Hub (and online)",
+  address: "2416 E 6th St",
+  city: "Austin",
+  state: "TX",
+};
+
+const EVENT_TIME_FORMAT = new Intl.DateTimeFormat("en-US", {
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZoneName: "short",
+  timeZone: "America/Chicago",
+});
+
+function isUndefinedVenue(venue: MeetupEvent["venue"]): boolean {
+  return (
+    isEmptyString(venue.address) ||
+    isEmptyString(venue.city) ||
+    isEmptyString(venue.state)
+  );
+}
+
+export type SerializedMeetupEvent = SerializeFrom<MeetupEvent>;
+
+export default function NextEventInfo({
+  event,
+}: {
+  event: SerializedMeetupEvent;
+}) {
+  const venue = isUndefinedVenue(event.venue) ? DEFAULT_VENUE : event.venue;
+  const buttonPronoun = event.going <= 1 ? "us" : `${event.going} others`;
+  return (
+    <>
+      <MeetupLink link={event.shortUrl}>
+        Join {buttonPronoun} at our next meetup!
+      </MeetupLink>
+      <p className="text-xl font-bold">{event.title}</p>
+      <p>
+        <time dateTime={event.dateTime}>
+          {EVENT_TIME_FORMAT.format(new Date(event.dateTime))}
+        </time>
+      </p>
+      <p>{venue.name}</p>
+      <p>
+        {venue.address}, {venue.city}, {venue.state}
+      </p>
+    </>
+  );
+}

--- a/app/models/meetup.parsing.ts
+++ b/app/models/meetup.parsing.ts
@@ -1,0 +1,57 @@
+import type { InferType } from "yup";
+import { object, string, number, array, date } from "yup";
+
+const MEETUP_EVENT_SCHEMA = object({
+  title: string().required(),
+  shortUrl: string().required().url(),
+  venue: object({
+    name: string().required(),
+    address: string().defined().strict(true),
+    city: string().defined().strict(true),
+    state: string().defined().strict(true),
+  }).required(),
+  dateTime: date().required(),
+  going: number().required(),
+}).required();
+
+export interface MeetupEvent extends InferType<typeof MEETUP_EVENT_SCHEMA> {}
+
+const MEETUP_GROUP_BY_URL_NAME_SCHEMA = object({
+  link: string().required(),
+  memberships: object({
+    count: number().required(),
+  }).required(),
+  upcomingEvents: object({
+    edges: array()
+      .of(
+        object({
+          node: MEETUP_EVENT_SCHEMA,
+        }).required()
+      )
+      .required(),
+  }).required(),
+}).required();
+
+export interface MeetupGroupByUrlname
+  extends InferType<typeof MEETUP_GROUP_BY_URL_NAME_SCHEMA> {}
+
+const MEETUP_GROUP_RESPONSE_SCHEMA = object({
+  data: object({
+    groupByUrlname: MEETUP_GROUP_BY_URL_NAME_SCHEMA,
+  }).required(),
+}).required();
+
+export interface MeetupGroupResponse
+  extends InferType<typeof MEETUP_GROUP_RESPONSE_SCHEMA> {}
+
+export interface MeetupRequestBody {
+  variables: { urlname: string };
+  // TODO use gql utils for better typing
+  query: string;
+}
+
+export async function parseMeetupGroupResponse(
+  val: unknown
+): Promise<MeetupGroupResponse> {
+  return MEETUP_GROUP_RESPONSE_SCHEMA.validate(val);
+}

--- a/app/models/meetup.server.test.ts
+++ b/app/models/meetup.server.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+import { tryToFetchRemixAustinInfo } from "~/models/meetup.server";
+import { server } from "../../mocks/server";
+import { rest } from "msw";
+import type {
+  MeetupEvent,
+  MeetupGroupByUrlname,
+  MeetupGroupResponse,
+  MeetupRequestBody,
+} from "~/models/meetup.parsing";
+
+const MOCK_EVENT: MeetupEvent = {
+  title: "Title",
+  shortUrl: "https://short.url",
+  venue: {
+    name: "Online",
+    address: "",
+    city: "",
+    state: "",
+  },
+  dateTime: new Date("2022-01-01T01:00:00Z"),
+  going: 100,
+};
+
+const MOCK_GROUP: MeetupGroupByUrlname = {
+  link: "https://group.link",
+  memberships: {
+    count: 200,
+  },
+  upcomingEvents: {
+    edges: [{ node: MOCK_EVENT }],
+  },
+};
+describe("meetup.server", () => {
+  describe("getRemixAustinInfo", () => {
+    let lastRequestBody: MeetupRequestBody;
+
+    beforeEach(() => {
+      const noOp = () => {};
+      vi.spyOn(console, "warn").mockImplementation(noOp);
+      server.use(
+        rest.post("https://www.meetup.com/gql", async (req, res, context) => {
+          lastRequestBody = await req.json();
+          const response: MeetupGroupResponse = {
+            data: { groupByUrlname: MOCK_GROUP },
+          };
+          return res(context.status(200), context.json(response));
+        })
+      );
+    });
+
+    it("should call meetup api", async () => {
+      const event = await tryToFetchRemixAustinInfo();
+      expect(lastRequestBody).toBeDefined();
+      expect(lastRequestBody.variables).toEqual({ urlname: "remix-austin" });
+      // TODO use gql utils for better assertions
+      expect(lastRequestBody.query.includes("groupByUrlname")).toBeTruthy();
+      expect(event).toEqual(MOCK_GROUP);
+    });
+
+    describe("with a malformed response", () => {
+      beforeEach(() => {
+        server.use(
+          rest.post("https://www.meetup.com/gql", (req, res, context) =>
+            res(context.status(200), context.json({ data: {} }))
+          )
+        );
+      });
+
+      it("should return undefined", async () => {
+        const info = await tryToFetchRemixAustinInfo();
+        expect(info).toBeUndefined();
+      });
+    });
+
+    describe("with a 500 response", () => {
+      beforeEach(() => {
+        server.use(
+          rest.post("https://www.meetup.com/gql", (req, res, context) => {
+            const response: MeetupGroupResponse = {
+              data: { groupByUrlname: MOCK_GROUP },
+            };
+            return res(context.status(500), context.json(response));
+          })
+        );
+      });
+
+      it("should return undefined", async () => {
+        const info = await tryToFetchRemixAustinInfo();
+        expect(info).toBeUndefined();
+      });
+    });
+  });
+});

--- a/app/models/meetup.server.ts
+++ b/app/models/meetup.server.ts
@@ -1,0 +1,65 @@
+import type { MeetupRequestBody } from "~/models/meetup.parsing";
+import { parseMeetupGroupResponse } from "~/models/meetup.parsing";
+
+const REMIX_AUSTIN_MEETUP_URL = "remix-austin";
+const MEETUP_API = "https://www.meetup.com/gql";
+const JSON_HEADERS: HeadersInit = { Accept: "application/json" };
+
+// TODO use gql utils for typing
+const GET_GROUP_QUERY = `
+  query($urlname: String!) {
+   groupByUrlname(urlname: $urlname) {
+    link
+    memberships {
+     count
+    }
+    upcomingEvents(input: {first: 1}){
+     edges {
+      node {
+       title
+       shortUrl
+       venue {
+        name
+        address
+        city
+        state
+       }
+       dateTime
+       going
+      }
+     }
+    }
+   }
+  }
+`;
+
+async function getMeetupGroupInfo(url: string) {
+  const body: MeetupRequestBody = {
+    variables: { urlname: url },
+    query: GET_GROUP_QUERY,
+  };
+  return fetch(MEETUP_API, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: JSON_HEADERS,
+  })
+    .then((res) => {
+      if (res.ok) {
+        return res.json();
+      }
+      throw new Error(`Error fetching from Meetup API: ${res.statusText}`);
+    })
+    .then(parseMeetupGroupResponse);
+}
+
+/**
+ * @returns undefined if there is an error fetching info
+ */
+export async function tryToFetchRemixAustinInfo() {
+  return getMeetupGroupInfo(REMIX_AUSTIN_MEETUP_URL)
+    .then((res) => res.data.groupByUrlname)
+    .catch((e) => {
+      console.warn(`Error retrieving Meetup info (%s). Ignoring.`, e.message);
+      return undefined;
+    });
+}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,9 +1,14 @@
-import MeetupIcon from "~/components/icons/MeetupIcon";
 import DiscordHeaderImage from "~/images/discord-header.jpg";
 import HeroImage from "~/images/hero.jpg";
 import GivePresentationImage from "~/images/give-a-presentation.jpg";
 import { discordUrl } from "~/components/Navbar/SocialLinks";
 import type { LinksFunction } from "@remix-run/node";
+import { tryToFetchRemixAustinInfo } from "~/models/meetup.server";
+import { json } from "@remix-run/server-runtime";
+import { useLoaderData } from "@remix-run/react";
+import NextEventInfo from "~/components/NextEventInfo/NextEventInfo";
+import MeetupLink from "~/components/MeetupLink";
+import { meetupUrl } from "~/components/Navbar/SocialLinks";
 
 interface CardProps {
   altText: string;
@@ -55,7 +60,17 @@ export const links: LinksFunction = () => {
   return [{ rel: "preload", href: HeroImage, as: "image" }];
 };
 
+export async function loader() {
+  const group = await tryToFetchRemixAustinInfo();
+  const nextEvent =
+    group !== undefined && group.upcomingEvents.edges.length >= 1
+      ? group.upcomingEvents.edges[0].node
+      : undefined;
+  return json({ link: group?.link, nextEvent });
+}
+
 export default function Index() {
+  const { link, nextEvent } = useLoaderData<typeof loader>();
   return (
     <>
       <div
@@ -75,19 +90,17 @@ export default function Index() {
               />
             </div>
             <h1 className="mb-4 inline-block text-5xl font-bold">{h1Title}</h1>
-            <p className="mb-4">
+            <p className="mb-8">
               We are the premiere Remix community for developers in Austin, and
               we stream remotely all over the world!
             </p>
-            <a
-              href="https://www.meetup.com/remix-austin/"
-              className="btn-primary btn"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span className="mr-2">Join us on Meetup</span>
-              <MeetupIcon />
-            </a>
+            {nextEvent ? (
+              <NextEventInfo event={nextEvent} />
+            ) : (
+              <MeetupLink link={link || meetupUrl}>
+                Join us on Meetup!
+              </MeetupLink>
+            )}
           </div>
         </div>
       </div>

--- a/app/utils.test.ts
+++ b/app/utils.test.ts
@@ -1,4 +1,9 @@
-import { validateEmail, safeRedirect, getRedirectUrlIfWww } from "./utils";
+import {
+  validateEmail,
+  safeRedirect,
+  getRedirectUrlIfWww,
+  isEmptyString,
+} from "./utils";
 
 describe("utils", () => {
   describe("email validation", () => {
@@ -89,6 +94,32 @@ describe("utils", () => {
       const result = getRedirectUrlIfWww(requestUrl);
 
       expect(result).toBe(null);
+    });
+  });
+
+  describe("isEmptyString", () => {
+    test("should return true if empty string", () => {
+      expect(isEmptyString("")).toBe(true);
+      expect(isEmptyString("   ")).toBe(true);
+    });
+
+    test("should return false if string has contents", () => {
+      expect(isEmptyString("content")).toBe(false);
+      expect(isEmptyString("  content")).toBe(false);
+      expect(isEmptyString("content  ")).toBe(false);
+    });
+
+    test("should return false if not given a string", () => {
+      expect(isEmptyString(undefined)).toBe(false);
+      expect(isEmptyString(null)).toBe(false);
+      expect(isEmptyString(0)).toBe(false);
+      expect(isEmptyString(1)).toBe(false);
+      expect(isEmptyString(true)).toBe(false);
+      expect(isEmptyString(false)).toBe(false);
+      expect(isEmptyString({})).toBe(false);
+      expect(isEmptyString({ foo: "bar" })).toBe(false);
+      expect(isEmptyString([])).toBe(false);
+      expect(isEmptyString(["foo"])).toBe(false);
     });
   });
 

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,4 +1,5 @@
 import { useMatches } from "@remix-run/react";
+import type { ReactNode } from "react";
 import { useMemo } from "react";
 
 const DEFAULT_REDIRECT = "/";
@@ -65,3 +66,11 @@ export function useMatchesData(
 export function validateEmail(email: unknown): email is string {
   return typeof email === "string" && email.length > 3 && email.includes("@");
 }
+
+export function isEmptyString(val: unknown): boolean {
+  return typeof val === "string" && val.trim().length <= 0;
+}
+
+export type PropsWithRequiredChildren<P = unknown> = P & {
+  children: ReactNode;
+};

--- a/mocks/server.ts
+++ b/mocks/server.ts
@@ -1,0 +1,3 @@
+import { setupServer } from "msw/node";
+
+export const server = setupServer();

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "isbot": "^3.5.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "tiny-invariant": "^1.2.0"
+        "tiny-invariant": "^1.2.0",
+        "yup": "^0.32.11"
       },
       "devDependencies": {
         "@faker-js/faker": "^7.5.0",
@@ -3237,6 +3238,11 @@
       "dependencies": {
         "keyv": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -10277,8 +10283,12 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
@@ -11706,6 +11716,11 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
+    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -13089,6 +13104,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
     },
     "node_modules/property-information": {
       "version": "6.1.1",
@@ -15514,6 +15534,11 @@
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "dev": true
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -17093,6 +17118,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/zwitch": {
@@ -19436,6 +19478,11 @@
       "requires": {
         "keyv": "*"
       }
+    },
+    "@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
     },
     "@types/mdast": {
       "version": "3.0.10",
@@ -24587,8 +24634,12 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.castarray": {
       "version": "4.4.0",
@@ -25559,6 +25610,11 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
     },
     "nanoid": {
       "version": "3.3.4",
@@ -26548,6 +26604,11 @@
           "dev": true
         }
       }
+    },
+    "property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
     },
     "property-information": {
       "version": "6.1.1",
@@ -28492,6 +28553,11 @@
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "dev": true
     },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+    },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -29523,6 +29589,20 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      }
     },
     "zwitch": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "isbot": "^3.5.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "tiny-invariant": "^1.2.0"
+    "tiny-invariant": "^1.2.0",
+    "yup": "^0.32.11"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.5.0",

--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -1,15 +1,26 @@
 import { installGlobals } from "@remix-run/node";
 import "@testing-library/jest-dom/extend-expect";
-import { expect, afterEach } from "vitest";
+import { afterEach, beforeAll, expect } from "vitest";
 import { cleanup } from "@testing-library/react";
 import matchers from "@testing-library/jest-dom/matchers";
+import { server } from "../mocks/server";
 
 installGlobals();
 
 // extends Vitest's expect method with methods from react-testing-library
 expect.extend(matchers);
 
+const closeServer = () => server.close();
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "bypass" });
+  process.once("SIGINT", closeServer);
+  process.once("SIGTERM", closeServer);
+  return closeServer;
+});
+
 // runs a cleanup after each test case (e.g. clearing jsdom)
 afterEach(() => {
+  server.resetHandlers();
   cleanup();
 });


### PR DESCRIPTION
## Description
As is, the site doesn't have any functionality that leverages remix too much since it's a static site. In the hopes of having an example of SSR will still also providing some value, I've used the Meetup API in order to display the group's next listed event on the home page during the SSR. If there is no listed event then is displays the previous generic button. 

### Screenshots

| mobile | desktop|
|---|---|
| ![Screenshot 2022-12-04 at 17-23-58 Remix Austin 💿 A community   monthly Meetup event for Remix developers](https://user-images.githubusercontent.com/3979735/205522063-c19581ee-94e1-4816-8543-c7a70f229dc7.png) | ![Screenshot 2022-12-04 at 17-24-37 Remix Austin 💿 A community   monthly Meetup event for Remix developers](https://user-images.githubusercontent.com/3979735/205522059-2e0b3767-5e28-4be5-9ee2-678674a258b7.png)

### Notes
- I avoided testing pure presentation components (those type of tests are prone to rot) and focused on tests around functionality. if you want even deeper testing, i'll add
- the [meetup api](https://www.meetup.com/api/schema/#groupByUrlname) is open to the public and doesn't require auth
- some of the components on the index route were refactored into separate components to make the index route slimmer and more focused (and thus easier to reason about how the loader and the comp interact).
- The styling of the info is very straightforward. happy to make it fancier if someone has some ideas in a follow-up PR.