### PR TITLE
fix: Format date on the server

### DIFF
--- a/app/components/NextEventInfo/NextEventInfo.test.tsx
+++ b/app/components/NextEventInfo/NextEventInfo.test.tsx
@@ -13,7 +13,10 @@ const DEFAULT_ONLINE_EVENT: SerializedMeetupEvent = {
     city: "",
     state: "",
   },
-  dateTime: "2022-01-01T01:00:00Z",
+  dateTime: {
+    localDateTime: "2022-01-01T01:00:00Z",
+    formatted: "Fri, Dec 31, 7:00 PM CST",
+  },
   going: 100,
 };
 

--- a/app/components/NextEventInfo/NextEventInfo.tsx
+++ b/app/components/NextEventInfo/NextEventInfo.tsx
@@ -12,16 +12,6 @@ const DEFAULT_VENUE: Venue = {
   state: "TX",
 };
 
-const EVENT_TIME_FORMAT = new Intl.DateTimeFormat("en-US", {
-  weekday: "short",
-  month: "short",
-  day: "numeric",
-  hour: "numeric",
-  minute: "2-digit",
-  timeZoneName: "short",
-  timeZone: "America/Chicago",
-});
-
 function isValidVenue(venue: MeetupEvent["venue"]): venue is Venue {
   return (
     venue !== null &&
@@ -41,6 +31,7 @@ export default function NextEventInfo({
   const venue = isValidVenue(event.venue) ? event.venue : DEFAULT_VENUE;
 
   const buttonPronoun = event.going <= 1 ? "us" : `${event.going} others`;
+
   return (
     <>
       <MeetupLink link={event.shortUrl}>
@@ -48,8 +39,8 @@ export default function NextEventInfo({
       </MeetupLink>
       <p className="text-xl font-bold">{event.title}</p>
       <p>
-        <time dateTime={event.dateTime}>
-          {EVENT_TIME_FORMAT.format(new Date(event.dateTime))}
+        <time dateTime={event.dateTime.localDateTime}>
+          {event.dateTime.formatted}
         </time>
       </p>
       <p>{venue.name}</p>

--- a/app/models/meetup.parsing.ts
+++ b/app/models/meetup.parsing.ts
@@ -1,5 +1,15 @@
 import { z } from "zod";
 
+const formatEventDate = new Intl.DateTimeFormat("en-US", {
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZoneName: "short",
+  timeZone: "America/Chicago",
+});
+
 const meetupEventSchema = z.object({
   title: z.string(),
   shortUrl: z.string().url(),
@@ -11,7 +21,11 @@ const meetupEventSchema = z.object({
       state: z.string(),
     })
     .nullable(),
-  dateTime: z.string(),
+  dateTime: z.string().transform((dateTime) => ({
+    localDateTime: dateTime,
+    // Formatting on the server ensures there won't be a server-client hydration mismatch
+    formatted: formatEventDate.format(new Date(dateTime)),
+  })),
   going: z.number(),
 });
 

--- a/app/models/meetup.server.test.ts
+++ b/app/models/meetup.server.test.ts
@@ -18,7 +18,10 @@ const MOCK_EVENT: MeetupEvent = {
     city: "",
     state: "",
   },
-  dateTime: "2022-01-01T01:00:00Z",
+  dateTime: {
+    localDateTime: "2022-01-01T01:00:00Z",
+    formatted: "Fri, Dec 31, 7:00 PM CST",
+  },
   going: 100,
 };
 


### PR DESCRIPTION
Fixes #83

Formatting the date on the server and uses that to avoid a server-client mismatch.

To test you'll need to enable JS in `app/root.tsx`. Make sure there is no hydration warning.