### PR TITLE
Replace narrow non break space with normal space

### DIFF
--- a/app/components/NextEventInfo/NextEventInfo.tsx
+++ b/app/components/NextEventInfo/NextEventInfo.tsx
@@ -1,5 +1,5 @@
 import type { MeetupEvent } from "~/models/meetup.parsing";
-import { isEmptyString } from "~/utils";
+import { formatDateTime, isEmptyString } from "~/utils";
 import MeetupLink from "~/components/MeetupLink";
 import type { SerializeFrom } from "@remix-run/server-runtime";
 
@@ -11,26 +11,6 @@ const DEFAULT_VENUE: Venue = {
   city: "Austin",
   state: "TX",
 };
-
-const EVENT_TIME_FORMAT = new Intl.DateTimeFormat("en-US", {
-  weekday: "short",
-  month: "short",
-  day: "numeric",
-  hour: "numeric",
-  minute: "2-digit",
-  timeZoneName: "short",
-  timeZone: "America/Chicago",
-});
-
-function formatDateTime(dateTime: string) {
-  const narrownNonBreakSpace = String.fromCharCode(8239);
-
-  // Discrepency between server and client, see https://github.com/remix-austin/remixaustin-com/issues/83#issuecomment-1450654389
-  return EVENT_TIME_FORMAT.format(new Date(dateTime)).replaceAll(
-    narrownNonBreakSpace,
-    " "
-  );
-}
 
 function isValidVenue(venue: MeetupEvent["venue"]): venue is Venue {
   return (

--- a/app/components/NextEventInfo/NextEventInfo.tsx
+++ b/app/components/NextEventInfo/NextEventInfo.tsx
@@ -22,6 +22,16 @@ const EVENT_TIME_FORMAT = new Intl.DateTimeFormat("en-US", {
   timeZone: "America/Chicago",
 });
 
+function formatDateTime(dateTime: string) {
+  const narrownNonBreakSpace = String.fromCharCode(8239);
+
+  // Discrepency between server and client, see https://github.com/remix-austin/remixaustin-com/issues/83#issuecomment-1450654389
+  return EVENT_TIME_FORMAT.format(new Date(dateTime)).replaceAll(
+    narrownNonBreakSpace,
+    " "
+  );
+}
+
 function isValidVenue(venue: MeetupEvent["venue"]): venue is Venue {
   return (
     venue !== null &&
@@ -48,9 +58,7 @@ export default function NextEventInfo({
       </MeetupLink>
       <p className="text-xl font-bold">{event.title}</p>
       <p>
-        <time dateTime={event.dateTime}>
-          {EVENT_TIME_FORMAT.format(new Date(event.dateTime))}
-        </time>
+        <time dateTime={event.dateTime}>{formatDateTime(event.dateTime)}</time>
       </p>
       <p>{venue.name}</p>
       <p>

--- a/app/utils.test.ts
+++ b/app/utils.test.ts
@@ -3,6 +3,7 @@ import {
   safeRedirect,
   getRedirectUrlIfWww,
   isEmptyString,
+  formatDateTime,
 } from "./utils";
 
 describe("utils", () => {
@@ -123,10 +124,11 @@ describe("utils", () => {
     });
   });
 
-  // TODO
-  // describe("useMatchesData", () => {
-  //   it("safeRedirect", () => {
-  //     expect(validateEmail("kody@example.com")).toBe(true);
-  //   });
-  // });
+  describe("formatDateTime", () => {
+    it("Correctly formats a date string", () => {
+      const dateTime = "2023-03-08T15:06:39.096Z";
+      const formattedDateTime = formatDateTime(dateTime);
+      expect(formattedDateTime).toBe("Wed, Mar 8, 9:06 AM CST");
+    });
+  });
 });

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -74,3 +74,29 @@ export function isEmptyString(val: unknown): boolean {
 export type PropsWithRequiredChildren<P = unknown> = P & {
   children: ReactNode;
 };
+
+const eventTimeFormat = new Intl.DateTimeFormat("en-US", {
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZoneName: "short",
+  timeZone: "America/Chicago",
+});
+
+const NARROW_NON_BREAK_SPACE = String.fromCharCode(8239);
+
+// Note: if we have more date formatting needs we can seperate this function and others
+// into a dedicated utils file
+
+/**
+ * Formats an date string into a more human readable format
+ * For example: "2023-03-08T15:06:39.096Z" -> "Wed, Mar 8, 9:06 AM CST"
+ */
+export function formatDateTime(dateTime: string) {
+  // Discrepency between server and client, see https://github.com/remix-austin/remixaustin-com/issues/83#issuecomment-1450654389
+  return eventTimeFormat
+    .format(new Date(dateTime))
+    .replaceAll(NARROW_NON_BREAK_SPACE, " ");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "exclude": ["./e2e"],
   "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2019"],
+    "lib": ["DOM", "DOM.Iterable", "ES2021"],
     "types": ["vitest/globals"],
     "isolatedModules": true,
     "esModuleInterop": true,
@@ -10,7 +10,7 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "target": "ES2019",
+    "target": "ES2021",
     "strict": true,
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
A simpler alternative to #84

**To test**
- Enable JS in `root.tsx`
- Return the following from `routes/index.tsx` (since we don't have an upcoming event posted yet)
```ts
  return json({
    link: "meetup.com",
    nextEvent: {
      dateTime: "2022-01-01T01:00:00Z",
      going: 100,
      shortUrl: "meetup.com",
      title: "Awesome next meetup",
      venue: {
        name: "Online",
        address: "",
        city: "",
        state: "",
      },
    },
  });
```
- Ensure there are no hydrate errors

Closes #83 