### PR TITLE
Adjust blog e2e test

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -7,11 +7,10 @@ test.describe("Blog", () => {
   });
 
   test("has a title", async ({ page }) => {
-    const h1Title = "Blog";
     const year = new Date().getFullYear().toString();
     const copyrightText = `Copyright © ${year} Remix Austin - All rights reserved.`;
 
-    await expect(page.getByRole("heading", { name: h1Title })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^Blog$/ })).toBeVisible();
     await expect(page.getByText(copyrightText, { exact: true })).toBeVisible();
   });
 


### PR DESCRIPTION
This PR adjusts the e2e test for the blog page so that it doesn't look for duplicate header text. Currently, the e2e test looks for the word "Blog" in a header to make sure that the `/blog` route loads correctly. This would normally match the `<h1>` for the Blog page.

But if a blog post has the world "Blog" in its title, this will cause the test to fail since the blog post will have an `<h2>` in the `/blog` route that also has the word "Blog". The test will fail because it will find duplicate headers.

Adding regex to make sure that the test only looks for the word "Blog" and nothing else fixes this problem.