### PR TITLE
Update Dependencies (part 1)

### DIFF
--- a/app/components/NextEventInfo/NextEventInfo.tsx
+++ b/app/components/NextEventInfo/NextEventInfo.tsx
@@ -1,7 +1,7 @@
 import type { MeetupEvent } from "~/models/meetup.parsing";
 import { formatDateTime, isEmptyString } from "~/utils";
 import MeetupLink from "~/components/MeetupLink";
-import type { SerializeFrom } from "@remix-run/server-runtime";
+import type { SerializeFrom } from "@remix-run/node";
 
 type Venue = NonNullable<MeetupEvent["venue"]>;
 

--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -1,5 +1,5 @@
 import { Link, useLoaderData } from "@remix-run/react";
-import { type LoaderArgs } from "@remix-run/server-runtime";
+import { type LoaderArgs } from "@remix-run/node";
 import type { PostFrontMatterCollection } from "blog/models";
 import { PUBLISH_DATE_FORMATTER } from "~/utils";
 

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -4,7 +4,7 @@ import GivePresentationImage from "~/images/give-a-presentation.jpg";
 import { discordUrl } from "~/components/Navbar/SocialLinks";
 import type { LinksFunction } from "@remix-run/node";
 import { tryToFetchRemixAustinInfo } from "~/models/meetup.server";
-import { json } from "@remix-run/server-runtime";
+import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import NextEventInfo from "~/components/NextEventInfo/NextEventInfo";
 import MeetupLink from "~/components/MeetupLink";

--- a/app/routes/resource/get-all-front-matter.ts
+++ b/app/routes/resource/get-all-front-matter.ts
@@ -1,4 +1,4 @@
-import { type LoaderArgs } from "@remix-run/server-runtime";
+import { type LoaderArgs } from "@remix-run/node";
 import { type PostFrontMatterCollection } from "blog/models";
 import { FRONT_MATTER_CACHE_FILENAME } from "blog/paths";
 

--- a/app/routes/resource/get-blog-post.$slug.ts
+++ b/app/routes/resource/get-blog-post.$slug.ts
@@ -1,4 +1,4 @@
-import { type LoaderArgs } from "@remix-run/server-runtime";
+import { type LoaderArgs } from "@remix-run/node";
 import { bundleMdx } from "blog/parser";
 import { POSTS_BUILD_DIR } from "blog/paths";
 import invariant from "tiny-invariant";

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,9 @@
       "name": "remixaustin-com",
       "version": "1.0.0",
       "dependencies": {
-        "@prisma/client": "^4.3.1",
-        "@remix-run/node": "^1.7.5",
-        "@remix-run/react": "^1.7.5",
-        "@remix-run/serve": "^1.7.5",
-        "@remix-run/server-runtime": "^1.7.5",
-        "bcryptjs": "^2.4.3",
+        "@remix-run/node": "^1.15.0",
+        "@remix-run/react": "^1.15.0",
+        "@remix-run/serve": "^1.15.0",
         "daisyui": "2.38.0",
         "isbot": "^3.5.3",
         "mdx-bundler": "^9.2.1",
@@ -24,18 +21,16 @@
         "zod": "^3.20.2"
       },
       "devDependencies": {
-        "@faker-js/faker": "^7.5.0",
         "@playwright/test": "1.28.1",
-        "@remix-run/dev": "^1.7.5",
-        "@remix-run/eslint-config": "^1.7.5",
+        "@remix-run/dev": "^1.15.0",
+        "@remix-run/eslint-config": "^1.15.0",
         "@tailwindcss/typography": "0.5.7",
         "@testing-library/dom": "^8.18.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
-        "@types/bcryptjs": "^2.4.2",
         "@types/eslint": "^8.4.6",
-        "@types/node": "^18.7.18",
+        "@types/node": "^18.13.0",
         "@types/react": "^18.0.20",
         "@types/react-dom": "^18.0.6",
         "@types/ws": "^8.5.4",
@@ -44,7 +39,6 @@
         "autoprefixer": "^10.4.11",
         "binode": "^1.0.5",
         "c8": "^7.12.0",
-        "cookie": "^0.5.0",
         "cross-env": "^7.0.3",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
@@ -108,30 +102,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.4.tgz",
-      "integrity": "sha512-/DYyDpeCfaVinT40FPGdkkb+lYSKvsVuMjDAG7jPOWWiM1ibOaB9CXJAlc4d1QpP/U2q2P9jbrSlClKSErd55g==",
+      "version": "7.21.9",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.9.tgz",
+      "integrity": "sha512-FUGed8kfhyWvbYug/Un/VPJD41rDIgoVVcR+FuzhzOYyRz5uED+Gd3SLZml0Uw2l2aHFb7ZgdW5mGA3G2cCCnQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.4.tgz",
-      "integrity": "sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
+      "integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.4",
-        "@babel/helper-compilation-targets": "^7.21.4",
-        "@babel/helper-module-transforms": "^7.21.2",
-        "@babel/helpers": "^7.21.0",
-        "@babel/parser": "^7.21.4",
+        "@babel/generator": "^7.21.5",
+        "@babel/helper-compilation-targets": "^7.21.5",
+        "@babel/helper-module-transforms": "^7.21.5",
+        "@babel/helpers": "^7.21.5",
+        "@babel/parser": "^7.21.8",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.4",
-        "@babel/types": "^7.21.4",
+        "@babel/traverse": "^7.21.5",
+        "@babel/types": "^7.21.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -156,9 +150,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.3.tgz",
-      "integrity": "sha512-kfhmPimwo6k4P8zxNs8+T7yR44q1LdpsZdE1NkCsVlfiuTPRfnGgjaF8Qgug9q9Pou17u6wneYF0lDCZJATMFg==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.8.tgz",
+      "integrity": "sha512-HLhI+2q+BP3sf78mFUZNCGc10KEmoUqtUT1OCdMZsN+qr4qFeLUod62/zAnF3jNQstwyasDkZnVXwfK2Bml7MQ==",
       "dev": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -183,12 +177,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.4.tgz",
-      "integrity": "sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==",
+      "version": "7.21.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.9.tgz",
+      "integrity": "sha512-F3fZga2uv09wFdEjEQIJxXALXfz0+JaOb7SabvVMmjHxeVTuGW8wgE8Vp1Hd7O+zMTYtcfEISGRzPkeiaPPsvg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.4",
+        "@babel/types": "^7.21.5",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -222,25 +216,24 @@
       }
     },
     "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.18.9.tgz",
-      "integrity": "sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.21.5.tgz",
+      "integrity": "sha512-uNrjKztPLkUk7bpCNC0jEKDJzzkvel/W+HguzbN8krA+LPfC1CEobJEvAvGka2A/M+ViOqXdcRL0GqPUJSjx9g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-explode-assignable-expression": "^7.18.6",
-        "@babel/types": "^7.18.9"
+        "@babel/types": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.4.tgz",
-      "integrity": "sha512-Fa0tTuOXZ1iL8IeDFUWCzjZcn+sJGd9RZdH9esYVjEejGmzf+FFYQpMi/kZUk2kPy/q1H3/GPw7np8qar/stfg==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.5.tgz",
+      "integrity": "sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.21.4",
+        "@babel/compat-data": "^7.21.5",
         "@babel/helper-validator-option": "^7.21.0",
         "browserslist": "^4.21.3",
         "lru-cache": "^5.1.1",
@@ -278,19 +271,20 @@
       "dev": true
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.4.tgz",
-      "integrity": "sha512-46QrX2CQlaFRF4TkwfTt6nJD7IHq8539cCL7SDpqWSDeJKY1xylKKY5F/33mJhLZ3mFvKv2gGrVS6NkyF6qs+Q==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.8.tgz",
+      "integrity": "sha512-+THiN8MqiH2AczyuZrnrKL6cAxFRRQDKW9h1YkBvbgKmAm6mwiacig1qT73DHIWMGo40GRnsEfN3LA+E6NtmSw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-environment-visitor": "^7.21.5",
         "@babel/helper-function-name": "^7.21.0",
-        "@babel/helper-member-expression-to-functions": "^7.21.0",
+        "@babel/helper-member-expression-to-functions": "^7.21.5",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-replace-supers": "^7.20.7",
+        "@babel/helper-replace-supers": "^7.21.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
-        "@babel/helper-split-export-declaration": "^7.18.6"
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "semver": "^6.3.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -299,20 +293,39 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.4.tgz",
-      "integrity": "sha512-M00OuhU+0GyZ5iBBN9czjugzWrEq2vDpf/zCYHxxf93ul/Q5rv+a5h+/+0WnI1AebHNVtl5bFV0qsJoH23DbfA==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.8.tgz",
+      "integrity": "sha512-zGuSdedkFtsFHGbexAvNuipg1hbtitDLo2XE8/uf6Y9sOQV1xsYX/2pNbtedp/X0eU1pIt+kGvaqHCowkRbS5g==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
-        "regexpu-core": "^5.3.1"
+        "regexpu-core": "^5.3.1",
+        "semver": "^6.3.0"
       },
       "engines": {
         "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -342,22 +355,10 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz",
+      "integrity": "sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-explode-assignable-expression": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz",
-      "integrity": "sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -388,12 +389,12 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.21.0.tgz",
-      "integrity": "sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.21.5.tgz",
+      "integrity": "sha512-nIcGfgwpH2u4n9GG1HpStW5Ogx7x7ekiFHbjjFRKXbn5zUvqO9ZgotCO4x1aNbKn/x/xOUaXEhyNHCwtFCpxWg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.0"
+        "@babel/types": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -412,19 +413,19 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
-      "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.5.tgz",
+      "integrity": "sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-environment-visitor": "^7.21.5",
+        "@babel/helper-module-imports": "^7.21.4",
+        "@babel/helper-simple-access": "^7.21.5",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.2",
-        "@babel/types": "^7.21.2"
+        "@babel/traverse": "^7.21.5",
+        "@babel/types": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -443,9 +444,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
-      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz",
+      "integrity": "sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -470,29 +471,29 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.20.7.tgz",
-      "integrity": "sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.21.5.tgz",
+      "integrity": "sha512-/y7vBgsr9Idu4M6MprbOVUfH3vs7tsIfnVWv/Ml2xgwvyH6LTngdfbf5AdsKwkJy4zgy1X/kuNrEKvhhK28Yrg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-member-expression-to-functions": "^7.20.7",
+        "@babel/helper-environment-visitor": "^7.21.5",
+        "@babel/helper-member-expression-to-functions": "^7.21.5",
         "@babel/helper-optimise-call-expression": "^7.18.6",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.7",
-        "@babel/types": "^7.20.7"
+        "@babel/traverse": "^7.21.5",
+        "@babel/types": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
-      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.21.5.tgz",
+      "integrity": "sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.20.2"
+        "@babel/types": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -523,9 +524,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz",
+      "integrity": "sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -565,14 +566,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
-      "integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.5.tgz",
+      "integrity": "sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.0",
-        "@babel/types": "^7.21.0"
+        "@babel/traverse": "^7.21.5",
+        "@babel/types": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -664,9 +665,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz",
-      "integrity": "sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==",
+      "version": "7.21.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.9.tgz",
+      "integrity": "sha512-q5PNg/Bi1OpGgx5jYlvWZwAorZepEudDMCLtj967aeS7WMont7dUZI46M2XwcIQqvUlMxWfdLFu4S/qSxeUu5g==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1034,6 +1035,18 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
@@ -1179,12 +1192,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.20.7.tgz",
-      "integrity": "sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.21.5.tgz",
+      "integrity": "sha512-wb1mhwGOCaXHDTcsRYMKF9e5bbMgqwxtqa2Y1ifH96dXJPwbuLX9qHy3clhrxVqgMz7nyNXs8VkxdH8UBcjKqA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2"
+        "@babel/helper-plugin-utils": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1264,12 +1277,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.20.7.tgz",
-      "integrity": "sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.21.5.tgz",
+      "integrity": "sha512-TR653Ki3pAwxBxUe8srfF3e4Pe3FTA46uaNHYyQwIoM4oWKSoOZiDNyHJ0oIoDIUPSRQbQG7jzgVBX3FPVne1Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.21.5",
         "@babel/template": "^7.20.7"
       },
       "engines": {
@@ -1342,12 +1355,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.21.0.tgz",
-      "integrity": "sha512-LlUYlydgDkKpIY7mcBWvyPPmMcOphEyYA27Ef4xpbh1IiDNLr0kZsos2nf92vz3IccvJI25QUwp86Eo5s6HmBQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.21.5.tgz",
+      "integrity": "sha512-nYWpjKW/7j/I/mZkGVgHJXh4bA1sfdFnJoOXwJuj4m3Q2EraO/8ZyrkCau9P5tbHQk01RMSt6KYLCsW7730SXQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2"
+        "@babel/helper-plugin-utils": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1420,14 +1433,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.2.tgz",
-      "integrity": "sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.5.tgz",
+      "integrity": "sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.21.2",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-simple-access": "^7.20.2"
+        "@babel/helper-module-transforms": "^7.21.5",
+        "@babel/helper-plugin-utils": "^7.21.5",
+        "@babel/helper-simple-access": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1643,12 +1656,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.20.5.tgz",
-      "integrity": "sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.21.5.tgz",
+      "integrity": "sha512-ZoYBKDb6LyMi5yCsByQ5jmXsHAQDDYeexT1Szvlmui+lADvfSecr5Dxd/PkrTC3pAD182Fcju1VQkB4oCp9M+w==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.21.5",
         "regenerator-transform": "^0.15.1"
       },
       "engines": {
@@ -1768,12 +1781,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz",
-      "integrity": "sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.21.5.tgz",
+      "integrity": "sha512-LYm/gTOwZqsYohlvFUe/8Tujz75LqqVC2w+2qPHLR+WyWHGCZPN1KBpJCJn+4Bk4gOkQy/IXKIge6az5MqwlOg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.9"
+        "@babel/helper-plugin-utils": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1799,14 +1812,14 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.21.4.tgz",
-      "integrity": "sha512-2W57zHs2yDLm6GD5ZpvNn71lZ0B/iypSdIeq25OurDKji6AdzV07qp4s3n1/x5BqtiGaTrPN3nerlSCaC5qNTw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.21.5.tgz",
+      "integrity": "sha512-wH00QnTTldTbf/IefEVyChtRdw5RJvODT/Vb4Vcxq1AZvtXj6T0YeX0cAcXhI6/BdGuiP3GcNIL4OQbI2DVNxg==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.21.4",
-        "@babel/helper-compilation-targets": "^7.21.4",
-        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/compat-data": "^7.21.5",
+        "@babel/helper-compilation-targets": "^7.21.5",
+        "@babel/helper-plugin-utils": "^7.21.5",
         "@babel/helper-validator-option": "^7.21.0",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.20.7",
@@ -1831,6 +1844,7 @@
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
         "@babel/plugin-syntax-import-assertions": "^7.20.0",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
@@ -1840,22 +1854,22 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
-        "@babel/plugin-transform-arrow-functions": "^7.20.7",
+        "@babel/plugin-transform-arrow-functions": "^7.21.5",
         "@babel/plugin-transform-async-to-generator": "^7.20.7",
         "@babel/plugin-transform-block-scoped-functions": "^7.18.6",
         "@babel/plugin-transform-block-scoping": "^7.21.0",
         "@babel/plugin-transform-classes": "^7.21.0",
-        "@babel/plugin-transform-computed-properties": "^7.20.7",
+        "@babel/plugin-transform-computed-properties": "^7.21.5",
         "@babel/plugin-transform-destructuring": "^7.21.3",
         "@babel/plugin-transform-dotall-regex": "^7.18.6",
         "@babel/plugin-transform-duplicate-keys": "^7.18.9",
         "@babel/plugin-transform-exponentiation-operator": "^7.18.6",
-        "@babel/plugin-transform-for-of": "^7.21.0",
+        "@babel/plugin-transform-for-of": "^7.21.5",
         "@babel/plugin-transform-function-name": "^7.18.9",
         "@babel/plugin-transform-literals": "^7.18.9",
         "@babel/plugin-transform-member-expression-literals": "^7.18.6",
         "@babel/plugin-transform-modules-amd": "^7.20.11",
-        "@babel/plugin-transform-modules-commonjs": "^7.21.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.21.5",
         "@babel/plugin-transform-modules-systemjs": "^7.20.11",
         "@babel/plugin-transform-modules-umd": "^7.18.6",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.20.5",
@@ -1863,17 +1877,17 @@
         "@babel/plugin-transform-object-super": "^7.18.6",
         "@babel/plugin-transform-parameters": "^7.21.3",
         "@babel/plugin-transform-property-literals": "^7.18.6",
-        "@babel/plugin-transform-regenerator": "^7.20.5",
+        "@babel/plugin-transform-regenerator": "^7.21.5",
         "@babel/plugin-transform-reserved-words": "^7.18.6",
         "@babel/plugin-transform-shorthand-properties": "^7.18.6",
         "@babel/plugin-transform-spread": "^7.20.7",
         "@babel/plugin-transform-sticky-regex": "^7.18.6",
         "@babel/plugin-transform-template-literals": "^7.18.9",
         "@babel/plugin-transform-typeof-symbol": "^7.18.9",
-        "@babel/plugin-transform-unicode-escapes": "^7.18.10",
+        "@babel/plugin-transform-unicode-escapes": "^7.21.5",
         "@babel/plugin-transform-unicode-regex": "^7.18.6",
         "@babel/preset-modules": "^0.1.5",
-        "@babel/types": "^7.21.4",
+        "@babel/types": "^7.21.5",
         "babel-plugin-polyfill-corejs2": "^0.3.3",
         "babel-plugin-polyfill-corejs3": "^0.6.0",
         "babel-plugin-polyfill-regenerator": "^0.4.1",
@@ -1933,15 +1947,15 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.21.4.tgz",
-      "integrity": "sha512-sMLNWY37TCdRH/bJ6ZeeOH1nPuanED7Ai9Y/vH31IPqalioJ6ZNFUWONsakhv4r4n+I6gm5lmoE0olkgib/j/A==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.21.5.tgz",
+      "integrity": "sha512-iqe3sETat5EOrORXiQ6rWfoOg2y68Cs75B9wNxdPW4kixJxh7aXQE1KPdWLDniC24T/6dSnguF33W9j/ZZQcmA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.21.5",
         "@babel/helper-validator-option": "^7.21.0",
         "@babel/plugin-syntax-jsx": "^7.21.4",
-        "@babel/plugin-transform-modules-commonjs": "^7.21.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.21.5",
         "@babel/plugin-transform-typescript": "^7.21.3"
       },
       "engines": {
@@ -1983,19 +1997,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.4.tgz",
-      "integrity": "sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.5.tgz",
+      "integrity": "sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.4",
-        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/generator": "^7.21.5",
+        "@babel/helper-environment-visitor": "^7.21.5",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.4",
-        "@babel/types": "^7.21.4",
+        "@babel/parser": "^7.21.5",
+        "@babel/types": "^7.21.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -2004,12 +2018,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
-      "integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
+      "integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-string-parser": "^7.21.5",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       },
@@ -2052,9 +2066,9 @@
       "dev": true
     },
     "node_modules/@emotion/hash": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==",
       "dev": true
     },
     "node_modules/@esbuild-plugins/node-modules-polyfill": {
@@ -2531,16 +2545,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@faker-js/faker": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
-      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@fal-works/esbuild-plugin-global-externals": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz",
@@ -2944,37 +2948,12 @@
         "node": ">=14"
       }
     },
-    "node_modules/@prisma/client": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.13.0.tgz",
-      "integrity": "sha512-YaiiICcRB2hatxsbnfB66uWXjcRw3jsZdlAVxmx0cFcTc/Ad/sKdHCcWSnqyDX47vAewkjRFwiLwrOUjswVvmA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@prisma/engines-version": "4.13.0-50.1e7af066ee9cb95cf3a403c78d9aab3e6b04f37a"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "prisma": "*"
-      },
-      "peerDependenciesMeta": {
-        "prisma": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@prisma/engines": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.13.0.tgz",
       "integrity": "sha512-HrniowHRZXHuGT9XRgoXEaP2gJLXM5RMoItaY2PkjvuZ+iHc0Zjbm/302MB8YsPdWozAPHHn+jpFEcEn71OgPw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true
-    },
-    "node_modules/@prisma/engines-version": {
-      "version": "4.13.0-50.1e7af066ee9cb95cf3a403c78d9aab3e6b04f37a",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.13.0-50.1e7af066ee9cb95cf3a403c78d9aab3e6b04f37a.tgz",
-      "integrity": "sha512-fsQlbkhPJf08JOzKoyoD9atdUijuGBekwoOPZC3YOygXEml1MTtgXVpnUNchQlRSY82OQ6pSGQ9PxUe4arcSLQ=="
     },
     "node_modules/@remix-run/dev": {
       "version": "1.15.0",
@@ -3498,6 +3477,25 @@
         }
       }
     },
+    "node_modules/@remix-run/eslint-config/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@remix-run/eslint-config/node_modules/eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      }
+    },
     "node_modules/@remix-run/express": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-1.15.0.tgz",
@@ -3608,9 +3606,9 @@
       }
     },
     "node_modules/@remix-run/web-fetch": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.3.3.tgz",
-      "integrity": "sha512-DK9vA2tgsadcFPpxW4fvN198tiWpyPhwR0EYOuM4QjpDCz0G619c9RDMdyMy6a7Qb/jwiyx9SOPHWc65QAl+1g==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.3.4.tgz",
+      "integrity": "sha512-AUM1XBa4hcgeNt2CD86OlB5aDLlqdMl0uJ+89R8dPGx07I5BwMXnbopCaPAkvSBIoHeT/IoLWIuZrLi7RvXS+Q==",
       "dependencies": {
         "@remix-run/web-blob": "^3.0.4",
         "@remix-run/web-form-data": "^3.0.3",
@@ -3871,12 +3869,6 @@
       "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
       "dev": true
     },
-    "node_modules/@types/bcryptjs": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
-      "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==",
-      "dev": true
-    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -4088,9 +4080,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.15.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.12.tgz",
-      "integrity": "sha512-Wha1UwsB3CYdqUm2PPzh/1gujGCNtWVUYF0mB00fJFoR4gTyWTDPjSm+zBF787Ahw8vSGgBja90MkgFwvB86Dg==",
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
       "devOptional": true
     },
     "node_modules/@types/prop-types": {
@@ -4396,9 +4388,9 @@
       }
     },
     "node_modules/@vanilla-extract/babel-plugin-debug-ids": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vanilla-extract/babel-plugin-debug-ids/-/babel-plugin-debug-ids-1.0.2.tgz",
-      "integrity": "sha512-LjnbQWGeMwaydmovx8jWUR8BxLtLiPyq0xz5C8G5OvFhsuJxvavLdrBHNNizvr1dq7/3qZGlPv0znsvU4P44YA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@vanilla-extract/babel-plugin-debug-ids/-/babel-plugin-debug-ids-1.0.3.tgz",
+      "integrity": "sha512-vm4jYu1xhSa6ofQ9AhIpR3DkAp4c+eoR1Rpm8/TQI4DmWbmGbOjYRcqV0aWsfaIlNhN4kFuxFMKBNN9oG6iRzA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.20.7"
@@ -4834,9 +4826,9 @@
       }
     },
     "node_modules/@vanilla-extract/integration/node_modules/rollup": {
-      "version": "3.20.6",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.6.tgz",
-      "integrity": "sha512-2yEB3nQXp/tBQDN0hJScJQheXdvU2wFhh6ld7K/aiZ1vYcak6N/BKjY1QrU6BvO2JWYS8bEs14FRaxXosxy2zw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.23.0.tgz",
+      "integrity": "sha512-h31UlwEi7FHihLe1zbk+3Q7z1k/84rb9BSwmBSr/XjOCEaBJ2YyedQDuM0t/kfOS0IxM+vk1/zI9XxYj9V+NJQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4850,15 +4842,14 @@
       }
     },
     "node_modules/@vanilla-extract/integration/node_modules/vite": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.2.2.tgz",
-      "integrity": "sha512-PcNtT5HeDxb3QaSqFYkEum8f5sCVe0R3WK20qxgIvNBZPXU/Obxs/+ubBMeE7nLWeCo2LDzv+8hRYSlcaSehig==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.8.tgz",
+      "integrity": "sha512-uYB8PwN7hbMrf4j1xzGDk/lqjsZvCDbt/JC5dyfxc19Pg8kRm14LinK/uq+HSLNswZEoKmweGdtpbnxRtrAXiQ==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.17.5",
-        "postcss": "^8.4.21",
-        "resolve": "^1.22.1",
-        "rollup": "^3.18.0"
+        "postcss": "^8.4.23",
+        "rollup": "^3.21.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5455,11 +5446,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -6340,9 +6326,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.1.tgz",
-      "integrity": "sha512-d690npR7MC6P0gq4npTl5n2VQeNAmUrJ90n+MHiKS7W2+xno4o3F5GDEuylSdi6EJ3VssibSGXOa1r3YXD3Mhw==",
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.2.tgz",
+      "integrity": "sha512-nriW1nuJjUgvkEjIot1Spwakz52V9YkYHZAQG6A1eCgC8AA1p0zngrQEP9R0+V6hji5XilWKG1Bd0YRppmGimA==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.21.5"
@@ -7705,13 +7691,14 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+      "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
       "dev": true,
       "dependencies": {
         "debug": "^3.2.7",
-        "resolve": "^1.20.0"
+        "is-core-module": "^2.11.0",
+        "resolve": "^1.22.1"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -7873,17 +7860,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/eslint-import-resolver-node": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
-      "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^3.2.7",
-        "is-core-module": "^2.11.0",
-        "resolve": "^1.22.1"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/json5": {
@@ -12432,15 +12408,15 @@
       "dev": true
     },
     "node_modules/mlly": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.0.tgz",
-      "integrity": "sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.1.tgz",
+      "integrity": "sha512-1aMEByaWgBPEbWV2BOPEMySRrzl7rIHXmQxam4DM8jVjalTQDjpN2ZKOLUrwyhfZQO7IXHml2StcHMhooDeEEQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.2",
         "pathe": "^1.1.0",
-        "pkg-types": "^1.0.2",
-        "ufo": "^1.1.1"
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.1.2"
       }
     },
     "node_modules/morgan": {
@@ -13624,13 +13600,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.2.tgz",
-      "integrity": "sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
       "dev": true,
       "dependencies": {
         "jsonc-parser": "^3.2.0",
-        "mlly": "^1.1.1",
+        "mlly": "^1.2.0",
         "pathe": "^1.1.0"
       }
     },
@@ -13796,9 +13772,9 @@
       }
     },
     "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.1.tgz",
+      "integrity": "sha512-Zr/dB+IlXaEqdoslLHhhqecwj73vc3rDmOpsBNBEVk7P2aqAlz+Ijy0fFbU5Ie9PtreDOIgGa9MsLWakVGl+fA==",
       "dev": true,
       "dependencies": {
         "icss-utils": "^5.0.0",
@@ -13958,7 +13934,7 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.13.0.tgz",
       "integrity": "sha512-L9mqjnSmvWIRCYJ9mQkwCtj4+JDYYTdhoyo8hlsHNDXaZLh/b4hR0IoKIBbTKxZuyHQzLopb/+0Rvb69uGV7uA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/engines": "4.13.0"
@@ -16491,9 +16467,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
-      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
+      "integrity": "sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==",
       "dev": true
     },
     "node_modules/unbox-primitive": {
@@ -17147,9 +17123,9 @@
       }
     },
     "node_modules/vm2": {
-      "version": "3.9.17",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
-      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
+      "version": "3.9.19",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
+      "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
@@ -17573,9 +17549,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true,
       "engines": {
         "node": ">= 14"

--- a/package.json
+++ b/package.json
@@ -44,12 +44,9 @@
     "/public/build"
   ],
   "dependencies": {
-    "@prisma/client": "^4.3.1",
-    "@remix-run/node": "^1.7.5",
-    "@remix-run/react": "^1.7.5",
-    "@remix-run/serve": "^1.7.5",
-    "@remix-run/server-runtime": "^1.7.5",
-    "bcryptjs": "^2.4.3",
+    "@remix-run/node": "^1.15.0",
+    "@remix-run/react": "^1.15.0",
+    "@remix-run/serve": "^1.15.0",
     "daisyui": "2.38.0",
     "isbot": "^3.5.3",
     "mdx-bundler": "^9.2.1",
@@ -60,18 +57,16 @@
     "zod": "^3.20.2"
   },
   "devDependencies": {
-    "@faker-js/faker": "^7.5.0",
     "@playwright/test": "1.28.1",
-    "@remix-run/dev": "^1.7.5",
-    "@remix-run/eslint-config": "^1.7.5",
+    "@remix-run/dev": "^1.15.0",
+    "@remix-run/eslint-config": "^1.15.0",
     "@tailwindcss/typography": "0.5.7",
     "@testing-library/dom": "^8.18.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
-    "@types/bcryptjs": "^2.4.2",
     "@types/eslint": "^8.4.6",
-    "@types/node": "^18.7.18",
+    "@types/node": "^18.13.0",
     "@types/react": "^18.0.20",
     "@types/react-dom": "^18.0.6",
     "@types/ws": "^8.5.4",
@@ -80,7 +75,6 @@
     "autoprefixer": "^10.4.11",
     "binode": "^1.0.5",
     "c8": "^7.12.0",
-    "cookie": "^0.5.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
@@ -110,8 +104,5 @@
   "engines": {
     "node": ">=18.13.0",
     "npm": ">=8.19.3"
-  },
-  "prisma": {
-    "seed": "ts-node --require tsconfig-paths/register prisma/seed.ts"
   }
 }

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,7 +1,7 @@
 import { server } from "../mocks/server";
 import type { DefaultBodyType } from "msw";
 import { rest } from "msw";
-import type { LoaderArgs } from "@remix-run/server-runtime";
+import type { LoaderArgs } from "@remix-run/node";
 
 /**
  * Use <code>msw</code> in order to mock a request with a specified response.


### PR DESCRIPTION
- Switch imports from `@remix-run/server-runtime` to `@remix-run/node`. `@remix-run/server-runtime` was a neat idea that the Remix team put forward, but in practice I believe it causes some problems. Better to leverage `@remix-run/node` directly and remove it as a dependency
- Update all `@remix-run/` packages to [version 1.15.0](https://github.com/remix-run/remix/releases/tag/remix%401.15.0). I'm not updating to 1.16.1 because that update currently causes dev to break. I'll keep working on that as I go/potentially open up a ticket for the Remix team.
- Remove some packages we are not using right now (`@prisma/client`, `bcryptjs `, `@faker-js/faker`, `cookie`)

I'm planning to opt us into all the [future flags](https://remix.run/blog/future-flags) in future PRs. Didn't want to make too many changes at once, so anticipate a series of PRs along these lines 🙂 